### PR TITLE
fix: admin settings page is broken with Give 2.5.0 #10

### DIFF
--- a/includes/class-give-convertkit.php
+++ b/includes/class-give-convertkit.php
@@ -66,9 +66,6 @@ class Give_ConvertKit_Settings {
 		add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
 		add_action( 'save_post', array( $this, 'save_metabox' ) );
 		
-		// add_filter( 'give_get_sections_gateways', array( $this, 'register_sections' ) );
-		// add_filter( 'give_get_settings_gateways', array( $this, 'register_settings' ) );		
-		
 		add_filter( 'give_get_sections_addons', array( $this, 'register_sections' ) );
 		add_filter( 'give_get_settings_addons', array( $this, 'register_settings' ) );
 		add_action( 'give_donation_form_before_submit', array( $this, 'form_fields' ), 100, 1 );
@@ -81,14 +78,8 @@ class Give_ConvertKit_Settings {
 		add_action( 'init', array( $this, 'init' ) );
 
 		// Custom fields.
-		// add_action( 'cmb2_render_give_convertkit_list_select', array(
-		// 	$this,
-		// 	'give_convertkit_list_select',
-		// ), 10, 5 );
-		// add_action( 'cmb2_render_give_convertkit_tag_list', array(
-		// 	$this,
-		// 	'give_convertkit_tag_list',
-		// ), 10, 5 );
+		add_action( 'give_admin_field_convertkit_list_select', array( $this, 'convertkit_list_select_field' ), 10, 2 );
+		add_action( 'give_admin_field_convertkit_tag_list', array( $this, 'convertkit_tag_list_field' ), 10, 2 );
 
 		add_action( 'wp_ajax_give_reset_convertkit_lists', array( $this, 'give_reset_convertkit_lists' ) );
 		add_action( 'wp_ajax_give_reset_convertkit_tags', array( $this, 'give_reset_convertkit_tags' ) );
@@ -687,13 +678,13 @@ class Give_ConvertKit_Settings {
 						'id'   => 'give_convertkit_list',
 						'name' => __( 'Choose a Form', 'give-convertkit' ),
 						'desc' => __( 'Select the form you wish to subscribe donors to by default.', 'give-convertkit' ),
-						'type' => 'give_convertkit_list_select',
+						'type' => 'convertkit_list_select',
 					),
 					array(
 						'id'   => '_give_convertkit_tags',
 						'name' => __( 'Choose Tags', 'give-convertkit' ),
 						'desc' => __( 'Select the tags you wish to subscribe donors to by default.', 'give-convertkit' ),
-						'type' => 'give_convertkit_tag_list',
+						'type' => 'convertkit_tag_list',
 					),
 					array(
 						'id'      => 'give_convertkit_checked_default',
@@ -760,32 +751,35 @@ class Give_ConvertKit_Settings {
 	 *
 	 * @param $field
 	 * @param $value
-	 * @param $object_id
-	 * @param $object_type
-	 * @param $field_type CMB2_Types
+	 * 
+	 * @since  1.0.3
+	 * @access public
 	 */
-	public function give_convertkit_list_select( $field, $value, $object_id, $object_type, $field_type ) {
+	public function convertkit_list_select_field( $field, $value ) {
 
-		ob_start(); ?>
-		<div class="give-convertkit-lists">
-			<label class=""
-			       for="<?php echo "{$field->args['id']}"; ?>"><?php _e( '', 'give-convertkit' ); ?></label>
+		ob_start();
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $field['id'] ); ?>">
+					<?php echo esc_attr( $field['name'] ); ?>
+				</label>
+			</th>
+			<td scope="row" class="">
+				<select class="give-convertkit-list-select" name="<?php echo "{$field['id']}"; ?>" id="<?php echo "{$field['id']}"; ?>">
+					<?php echo $this->get_list_options( $this->get_lists(), $value ); ?>
+				</select>
 
-			<select class="cmb2_select give-convertkit-list-select" name="<?php echo "{$field->args['id']}"; ?>"
-			        id="<?php echo "{$field->args['id']}"; ?>">
-				<?php echo $this->get_list_options( $this->get_lists(), $value ); ?>
-			</select>
+				<button class="give-reset-convertkit-button button-secondary" style="margin:3px 0 0 2px !important;" data-action="give_reset_convertkit_lists" data-field_type="select">
+					<?php echo esc_html__( 'Refresh Lists', 'give-convertkit' ); ?>
+				</button>
+				<span class="give-spinner spinner"></span>
 
-			<button class="give-reset-convertkit-button button-secondary" style="margin:3px 0 0 2px !important;"
-			        data-action="give_reset_convertkit_lists"
-			        data-field_type="select"><?php echo esc_html__( 'Refresh Lists', 'give-convertkit' ); ?></button>
-			<span class="give-spinner spinner"></span>
-
-			<p class="cmb2-metabox-description give-description"><?php echo "{$field->args['desc']}"; ?></p>
-
-		</div>
-
-		<?php echo ob_get_clean();
+				<p class="give-description"><?php echo "{$field['desc']}"; ?></p>
+			</td>
+		</tr>
+		<?php
+		echo ob_get_clean();
 	}
 
 	/**
@@ -793,35 +787,37 @@ class Give_ConvertKit_Settings {
 	 *
 	 * @param $field
 	 * @param $value
-	 * @param $object_id
-	 * @param $object_type
-	 * @param $field_type CMB2_Types
+	 * 
+	 * @since  1.0.3
+	 * @access public
 	 */
-	public function give_convertkit_tag_list( $field, $value, $object_id, $object_type, $field_type ) {
+	public function convertkit_tag_list_field( $field, $value ) {
 
-		ob_start(); ?>
-		<div class="give-convertkit-lists">
-			<label class=""
-			       for="<?php echo "{$field->args['id']}"; ?>"><?php _e( '', 'give-convertkit' ); ?></label>
+		ob_start(); 
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $field['id'] ); ?>">
+					<?php echo esc_attr( $field['name'] ); ?>
+				</label>
+			</th>
+			<td scope="row" class="">
+				<div class="give-<?php echo $this->id; ?>-tag-wrap">
+					<?php
+					$checked = give_get_option( "{$field['id']}" );
+					echo $this->get_tag_options( $this->get_tags(), $checked, 'checkbox' ); ?>
+				</div>
 
+				<p class="give-description"><?php echo "{$field['desc']}"; ?></p>
 
-			<div class="give-<?php echo $this->id; ?>-tag-wrap">
-				<?php
-				$checked = give_get_option( "{$field->args['id']}" );
-				echo $this->get_tag_options( $this->get_tags(), $checked, 'checkbox' ); ?>
-			</div>
-
-			<p class="cmb2-metabox-description give-description"><?php echo "{$field->args['desc']}"; ?></p>
-
-			<button class="give-reset-tags-convertkit-button button-secondary" style="margin:3px 0 0 0 !important;"
-			        data-action="give_reset_convertkit_tags"
-			        data-field_type="checklist"><?php esc_html_e( 'Refresh Tags', 'give-convertkit' ); ?></button>
-			<span class="give-spinner spinner"></span>
-
-
-		</div>
-
-		<?php echo ob_get_clean();
+				<button class="give-reset-tags-convertkit-button button-secondary" style="margin:3px 0 0 0 !important;"
+						data-action="give_reset_convertkit_tags"
+						data-field_type="checklist"><?php esc_html_e( 'Refresh Tags', 'give-convertkit' ); ?></button>
+				<span class="give-spinner spinner"></span>
+			</td>
+		</tr>
+		<?php
+		echo ob_get_clean();
 	}
 
 	/**

--- a/includes/class-give-convertkit.php
+++ b/includes/class-give-convertkit.php
@@ -1,4 +1,18 @@
 <?php
+/**
+ * Give ConvertKit - Admin Settings
+ *
+ * @package    Give
+ * @subpackage Includes/Admin/Settings
+ * @copyright  Copyright (c) 2019, GiveWP
+ * @license    https://opensource.org/licenses/gpl-license GNU Public License
+ * @since      1.0.3
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Class Give_ConvertKit
@@ -51,8 +65,12 @@ class Give_ConvertKit_Settings {
 
 		add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
 		add_action( 'save_post', array( $this, 'save_metabox' ) );
-
-		add_filter( 'give_settings_addons', array( $this, 'settings' ) );
+		
+		// add_filter( 'give_get_sections_gateways', array( $this, 'register_sections' ) );
+		// add_filter( 'give_get_settings_gateways', array( $this, 'register_settings' ) );		
+		
+		add_filter( 'give_get_sections_addons', array( $this, 'register_sections' ) );
+		add_filter( 'give_get_settings_addons', array( $this, 'register_settings' ) );
 		add_action( 'give_donation_form_before_submit', array( $this, 'form_fields' ), 100, 1 );
 		add_action( 'give_insert_payment', array( $this, 'completed_donation_signup' ), 10, 2 );
 
@@ -63,14 +81,14 @@ class Give_ConvertKit_Settings {
 		add_action( 'init', array( $this, 'init' ) );
 
 		// Custom fields.
-		add_action( 'cmb2_render_give_convertkit_list_select', array(
-			$this,
-			'give_convertkit_list_select',
-		), 10, 5 );
-		add_action( 'cmb2_render_give_convertkit_tag_list', array(
-			$this,
-			'give_convertkit_tag_list',
-		), 10, 5 );
+		// add_action( 'cmb2_render_give_convertkit_list_select', array(
+		// 	$this,
+		// 	'give_convertkit_list_select',
+		// ), 10, 5 );
+		// add_action( 'cmb2_render_give_convertkit_tag_list', array(
+		// 	$this,
+		// 	'give_convertkit_tag_list',
+		// ), 10, 5 );
 
 		add_action( 'wp_ajax_give_reset_convertkit_lists', array( $this, 'give_reset_convertkit_lists' ) );
 		add_action( 'wp_ajax_give_reset_convertkit_tags', array( $this, 'give_reset_convertkit_tags' ) );
@@ -609,75 +627,104 @@ class Give_ConvertKit_Settings {
 	}
 
 	/**
+	 * Register sections.
+	 *
+	 * @since  1.0.3
+	 * @access public
+	 *
+	 * @param array $sections List of sections.
+	 *
+	 * @return mixed
+	 */
+	public function register_sections( $sections ) {
+		$sections['convertkit-settings'] = __( 'Convertkit Settings', 'give-convertkit' );
+
+		return $sections;
+	}
+
+	/**
 	 * Registers the plugin's settings.
 	 *
 	 * @param $settings
 	 *
 	 * @return array
 	 */
-	public function settings( $settings ) {
+	public function register_settings( $settings ) {
 
-		$give_convertkit_settings = array(
-			array(
-				'name' => __( 'ConvertKit Settings', 'give-convertkit' ),
-				'desc' => '<hr>',
-				'id'   => 'give_title_' . $this->id,
-				'type' => 'give_title',
-			),
-			array(
-				'id'   => 'give_convertkit_api',
-				'name' => __( 'ConvertKit API Key', 'give-convertkit' ),
-				'desc' => sprintf( __( 'Enter your ConvertKit API key. You may retrieve your ConvertKit API key from your <a href="%s" target="_blank" title="Will open new window">account settings</a>.', 'give-convertkit' ), 'https://app.convertkit.com/account/edit' ),
-				'type' => 'text',
-				'size' => 'regular',
-			),
-			array(
-				'id'      => 'give_convertkit_show_subscribe_checkbox',
-				'name'    => __( 'Enable Globally', 'give-convertkit' ),
-				'desc'    => __( 'Allow donors to sign up for the forms selected below on all donation forms? Note: the forms(s) can be customized per form.', 'give-convertkit' ),
-				'type'    => 'radio_inline',
-				'default' => 'enabled',
-				'options' => array(
-					'enabled'  => __( 'Enabled', 'give-convertkit' ),
-					'disabled' => __( 'Disabled', 'give-convertkit' ),
-				),
-			),
-			array(
-				'id'   => 'give_convertkit_list',
-				'name' => __( 'Choose a Form', 'give-convertkit' ),
-				'desc' => __( 'Select the form you wish to subscribe donors to by default.', 'give-convertkit' ),
-				'type' => 'give_convertkit_list_select',
-			),
-			array(
-				'id'   => '_give_convertkit_tags',
-				'name' => __( 'Choose Tags', 'give-convertkit' ),
-				'desc' => __( 'Select the tags you wish to subscribe donors to by default.', 'give-convertkit' ),
-				'type' => 'give_convertkit_tag_list',
-			),
-			array(
-				'id'      => 'give_convertkit_checked_default',
-				'name'    => __( 'Opt-in Default', 'give-convertkit' ),
-				'desc'    => __( 'Would you like the newsletter opt-in checkbox checked by default? This option can be customized per form.', 'give-convertkit' ),
-				'options' => array(
-					'enabled'  => __( 'Checked', 'give-convertkit' ),
-					'disabled' => __( 'Unchecked', 'give-convertkit' ),
-				),
-				'default' => 'enabled',
-				'type'    => 'radio_inline',
-			),
-			array(
-				'id'         => 'give_convertkit_label',
-				'name'       => __( 'Default Label', 'give-convertkit' ),
-				'desc'       => __( 'This is the text shown next to the signup option. This can also be customized per form.', 'give-convertkit' ),
-				'type'       => 'text',
-				'size'       => 'regular',
-				'attributes' => array(
-					'placeholder' => __( 'Subscribe to our newsletter', 'give-convertkit' ),
-				),
-			),
-		);
+		switch ( give_get_current_setting_section() ) {
+			
+			case 'convertkit-settings':
+				$settings = array(
+					array(
+						'id'   => 'give_title_convertkit',
+						'type' => 'title',
+					),
+					array(
+						'name' => __( 'ConvertKit Settings', 'give-convertkit' ),
+						'desc' => '<hr>',
+						'id'   => 'give_title_' . $this->id,
+						'type' => 'give_title',
+					),
+					array(
+						'id'   => 'give_convertkit_api',
+						'name' => __( 'ConvertKit API Key', 'give-convertkit' ),
+						'desc' => sprintf( __( 'Enter your ConvertKit API key. You may retrieve your ConvertKit API key from your <a href="%s" target="_blank" title="Will open new window">account settings</a>.', 'give-convertkit' ), 'https://app.convertkit.com/account/edit' ),
+						'type' => 'text',
+						'size' => 'regular',
+					),
+					array(
+						'id'      => 'give_convertkit_show_subscribe_checkbox',
+						'name'    => __( 'Enable Globally', 'give-convertkit' ),
+						'desc'    => __( 'Allow donors to sign up for the forms selected below on all donation forms? Note: the forms(s) can be customized per form.', 'give-convertkit' ),
+						'type'    => 'radio_inline',
+						'default' => 'enabled',
+						'options' => array(
+							'enabled'  => __( 'Enabled', 'give-convertkit' ),
+							'disabled' => __( 'Disabled', 'give-convertkit' ),
+						),
+					),
+					array(
+						'id'   => 'give_convertkit_list',
+						'name' => __( 'Choose a Form', 'give-convertkit' ),
+						'desc' => __( 'Select the form you wish to subscribe donors to by default.', 'give-convertkit' ),
+						'type' => 'give_convertkit_list_select',
+					),
+					array(
+						'id'   => '_give_convertkit_tags',
+						'name' => __( 'Choose Tags', 'give-convertkit' ),
+						'desc' => __( 'Select the tags you wish to subscribe donors to by default.', 'give-convertkit' ),
+						'type' => 'give_convertkit_tag_list',
+					),
+					array(
+						'id'      => 'give_convertkit_checked_default',
+						'name'    => __( 'Opt-in Default', 'give-convertkit' ),
+						'desc'    => __( 'Would you like the newsletter opt-in checkbox checked by default? This option can be customized per form.', 'give-convertkit' ),
+						'options' => array(
+							'enabled'  => __( 'Checked', 'give-convertkit' ),
+							'disabled' => __( 'Unchecked', 'give-convertkit' ),
+						),
+						'default' => 'enabled',
+						'type'    => 'radio_inline',
+					),
+					array(
+						'id'         => 'give_convertkit_label',
+						'name'       => __( 'Default Label', 'give-convertkit' ),
+						'desc'       => __( 'This is the text shown next to the signup option. This can also be customized per form.', 'give-convertkit' ),
+						'type'       => 'text',
+						'size'       => 'regular',
+						'attributes' => array(
+							'placeholder' => __( 'Subscribe to our newsletter', 'give-convertkit' ),
+						),
+					),
+					array(
+						'id'   => 'give_title_convertkit',
+						'type' => 'sectionend',
+					),
+				);
+				break;
+		}
 
-		return array_merge( $settings, $give_convertkit_settings );
+		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR resolves #10 

## How Has This Been Tested?
I've tested this PR with `master` as well as `release/2.5.0` branch of Give core.

## Screenshots (jpeg or gifs if applicable):
**Master Branch of Give Core**
![image](https://user-images.githubusercontent.com/1852711/58702432-7073a800-83c3-11e9-90c5-c506328675fa.png)

**Release/2.5.0 branch of Give core**
![image](https://user-images.githubusercontent.com/1852711/58702478-913bfd80-83c3-11e9-97a2-9fb3f9f29734.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.