### PR TITLE
Refactor: add multiple list subscription support

### DIFF
--- a/src/ConvertKitAPI/API.php
+++ b/src/ConvertKitAPI/API.php
@@ -119,23 +119,10 @@ class API
         );
 
         $successfulResponse = in_array(wp_remote_retrieve_response_code($response), [200, 201]);
-
-        $httpMessages = [
-            'tags'  => [
-                'success' => __('Convertkit API has successfully added a new email tag'),
-                'error'   => __('Convertkit API has encountered an error while subscribing a new email tag'),
-            ],
-            'forms' => [
-                'success' => __('Convertkit API has successfully subscribed a new email'),
-                'error'   => __('Convertkit API has encountered an error while subscribing a new email'),
-            ],
-        ];
-
-        $httpSuccessMessage = isset($httpMessages[$entity]) && $httpMessages[$entity]['success'];
-        $httpErrorMessage = isset($httpMessages[$entity]) && $httpMessages[$entity]['error'];
+        $httpMessage = $this->getHttpMessages($entity, $successfulResponse);
 
         if (is_wp_error($response)) {
-            Log::error($httpErrorMessage, [
+            Log::error($httpMessage, [
                 'id'         => $id,
                 'error'      => $response->get_error_message(),
                 'subscriber' => $subscriber->toArray(),
@@ -145,7 +132,7 @@ class API
         }
 
         if ( ! $successfulResponse) {
-            Log::error($httpErrorMessage, [
+            Log::error($httpMessage, [
                 'id'         => $id,
                 'error'      => wp_remote_retrieve_body($response),
                 'subscriber' => $subscriber->toArray(),
@@ -155,13 +142,29 @@ class API
         }
 
         Log::success(
-            $httpSuccessMessage,
+            $httpMessage,
             [
                 'id'         => $id,
                 'response'   => wp_remote_retrieve_body($response),
                 'subscriber' => $subscriber->toArray(),
             ]
         );
+    }
+
+    protected function getHttpMessages($entity, $successfulResponse): string
+    {
+        $httpMessages = [
+            'tags'  => [
+                'success' => __('Convertkit API has successfully added a new email tag'),
+                'error'   => __('Convertkit API has encountered an error while adding a new email tag'),
+            ],
+            'forms' => [
+                'success' => __('Convertkit API has successfully subscribed a new email'),
+                'error'   => __('Convertkit API has encountered an error while subscribing a new email'),
+            ],
+        ];
+
+        return $successfulResponse ? $httpMessages[$entity]['success'] : $httpMessages[$entity]['error'];
     }
 }
 

--- a/src/ConvertKitAPI/API.php
+++ b/src/ConvertKitAPI/API.php
@@ -136,12 +136,13 @@ class API
 
         if ($responseCode === 200) {
             $httpMessage = $entity === 'tags' ?
-                'Convertkit API has successfully subscribed a new email tag' :
+                'Convertkit API has successfully added a new email tag' :
                 'Convertkit API has successfully subscribed a new email';
 
             Log::http(
                 $httpMessage,
                 [
+                    'id'         => $id,
                     'response'   => $response,
                     'subscriber' => $subscriber->toArray(),
                 ]

--- a/src/ConvertKitAPI/API.php
+++ b/src/ConvertKitAPI/API.php
@@ -93,7 +93,7 @@ class API
      */
     protected function get($entity): array
     {
-        if (!$this->validateApiCredentials()) {
+        if ( ! $this->validateApiCredentials()) {
             return [];
         }
 
@@ -118,12 +118,13 @@ class API
             ['body' => $subscriber->toArray(), 'timeout' => 30]
         );
 
+        $responseCode = wp_remote_retrieve_response_code($response);
+
         if (is_wp_error($response)) {
             Log::error(__('Error subscribing to ConvertKit', 'give-convertkit'), [
                 'error'      => $response->get_error_message(),
                 'subscriber' => $subscriber->toArray(),
             ]);
-            return;
         }
 
         if ( ! in_array(wp_remote_retrieve_response_code($response), [200, 201])) {
@@ -131,16 +132,20 @@ class API
                 'error'      => wp_remote_retrieve_body($response),
                 'subscriber' => $subscriber->toArray(),
             ]);
-            return;
         }
 
-        $httpMessage = $entity === 'tags' ?
-            'Convertkit API has successfully subscribed a new email tag' :
-            'Convertkit API has successfully subscribed a new email';
+        if ($responseCode === 200) {
+            $httpMessage = $entity === 'tags' ?
+                'Convertkit API has successfully subscribed a new email tag' :
+                'Convertkit API has successfully subscribed a new email';
 
-            Log::http($httpMessage,
-                ['response' => $response,
-                 'subscriber' => $subscriber->toArray(),
-                ]);
+            Log::http(
+                $httpMessage,
+                [
+                    'response'   => $response,
+                    'subscriber' => $subscriber->toArray(),
+                ]
+            );
+        }
     }
 }

--- a/src/ConvertKitAPI/API.php
+++ b/src/ConvertKitAPI/API.php
@@ -75,7 +75,7 @@ class API
     /**
      * @unreleased
      */
-    public function subscribeToFormList($id, Subscriber $subscriber)
+    public function subscribeToFormList($id, Subscriber $subscriber): void
     {
         $this->subscribe('forms', $id, $subscriber);
     }
@@ -83,7 +83,7 @@ class API
     /**
      * @unreleased
      */
-    public function subscriberToTag($id, Subscriber $subscriber)
+    public function subscriberToTag($id, Subscriber $subscriber): void
     {
         $this->subscribe('tags', $id, $subscriber);
     }
@@ -102,7 +102,7 @@ class API
 
         return array_map(function ($item) {
             return [
-                'id'   => $item['id'],
+                'id'   => (string)$item['id'],
                 'name' => $item['name'],
             ];
         }, $list[$entity]);
@@ -111,42 +111,57 @@ class API
     /**
      * @unreleased
      */
-    protected function subscribe($entity, $id, Subscriber $subscriber): void
+    protected function subscribe($entity, $id, Subscriber $subscriber)
     {
         $response = wp_remote_post(
-            "https://api.convertkit.com/v3/$entity/$id/subscribe?api_key={$this->apiKey}",
-            ['body' => $subscriber->toArray(), 'timeout' => 30]
+            "https://api.convertkit.com/v3/$entity/#$id/subscribe?$this->apiKey)",
+            ['body' => $subscriber->toArray()]
         );
 
-        $responseCode = wp_remote_retrieve_response_code($response);
+        $successfulResponse = in_array(wp_remote_retrieve_response_code($response), [200, 201]);
+
+        $httpMessages = [
+            'tags'  => [
+                'success' => __('Convertkit API has successfully added a new email tag'),
+                'error'   => __('Convertkit API has encountered an error while subscribing a new email tag'),
+            ],
+            'forms' => [
+                'success' => __('Convertkit API has successfully subscribed a new email'),
+                'error'   => __('Convertkit API has encountered an error while subscribing a new email'),
+            ],
+        ];
+
+        $httpSuccessMessage = isset($httpMessages[$entity]) && $httpMessages[$entity]['success'];
+        $httpErrorMessage = isset($httpMessages[$entity]) && $httpMessages[$entity]['error'];
 
         if (is_wp_error($response)) {
-            Log::error(__('Error subscribing to ConvertKit', 'give-convertkit'), [
+            Log::error($httpErrorMessage, [
+                'id'         => $id,
                 'error'      => $response->get_error_message(),
                 'subscriber' => $subscriber->toArray(),
             ]);
+
+            return;
         }
 
-        if ( ! in_array(wp_remote_retrieve_response_code($response), [200, 201])) {
-            Log::error(__('Error subscribing to ConvertKit', 'give-convertkit'), [
+        if ( ! $successfulResponse) {
+            Log::error($httpErrorMessage, [
+                'id'         => $id,
                 'error'      => wp_remote_retrieve_body($response),
                 'subscriber' => $subscriber->toArray(),
             ]);
+
+            return;
         }
 
-        if ($responseCode === 200) {
-            $httpMessage = $entity === 'tags' ?
-                'Convertkit API has successfully added a new email tag' :
-                'Convertkit API has successfully subscribed a new email';
-
-            Log::http(
-                $httpMessage,
-                [
-                    'id'         => $id,
-                    'response'   => $response,
-                    'subscriber' => $subscriber->toArray(),
-                ]
-            );
-        }
+        Log::success(
+            $httpSuccessMessage,
+            [
+                'id'         => $id,
+                'response'   => wp_remote_retrieve_body($response),
+                'subscriber' => $subscriber->toArray(),
+            ]
+        );
     }
 }
+

--- a/src/FormExtension/Actions/AddBlockToNewForms.php
+++ b/src/FormExtension/Actions/AddBlockToNewForms.php
@@ -65,7 +65,7 @@ class AddBlockToNewForms
      */
     protected function getSelectedForms()
     {
-        return give_get_option('give_convertkit_list');
+        return (array)give_get_option('give_convertkit_list', []);
     }
 
     /**

--- a/src/FormExtension/Actions/AddBlockToNewForms.php
+++ b/src/FormExtension/Actions/AddBlockToNewForms.php
@@ -18,7 +18,7 @@ class AddBlockToNewForms
     {
         $convertkit = give(API::class);
 
-        if (!$this->isEnabledGlobally() || !$convertkit->validateApiCredentials()) {
+        if ( ! $this->isEnabledGlobally() || ! $convertkit->validateApiCredentials()) {
             return;
         }
 
@@ -29,7 +29,7 @@ class AddBlockToNewForms
                 'attributes' => [
                     'label'          => $this->getLabel(),
                     'defaultChecked' => $this->getDefaultChecked(),
-                    'selectedForm'   => $this->getSelectedForm(),
+                    'selectedForms'  => $this->getSelectedForms(),
                     'tagSubscribers' => $this->getSelectedTags(),
                 ],
             ])
@@ -63,7 +63,7 @@ class AddBlockToNewForms
     /**
      * @unreleased
      */
-    protected function getSelectedForm()
+    protected function getSelectedForms()
     {
         return give_get_option('give_convertkit_list');
     }

--- a/src/FormExtension/Actions/RenderDonationFormBlock.php
+++ b/src/FormExtension/Actions/RenderDonationFormBlock.php
@@ -25,14 +25,14 @@ class RenderDonationFormBlock
     {
         $convertkit = give(API::class);
 
-        if (!$convertkit->validateApiCredentials()) {
+        if ( ! $convertkit->validateApiCredentials()) {
             return null;
         }
 
         return ConvertKitField::make('convertkit')
             ->label((string)$block->getAttribute('label'))
             ->checked((bool)$block->getAttribute('defaultChecked'))
-            ->selectedForm((string)$block->getAttribute('selectedForm'))
+            ->selectedForms((array)$block->getAttribute('selectedForm'))
             ->tagSubscribers((array)$block->getAttribute('tagSubscribers'))
             ->scope(function (ConvertKitField $field, $value, Donation $donation) {
                 // If the field is checked, subscribe the donor to the list.
@@ -40,8 +40,12 @@ class RenderDonationFormBlock
                     $convertkit = give(API::class);
                     $subscriber = \GiveConvertKit\ConvertKitAPI\Subscriber::fromDonor($donation->donor);
 
-                    if ($field->getSelectedForm()) {
-                        $convertkit->subscribeToFormList($field->getSelectedForm(), $subscriber);
+                    if (is_array($field->getSelectedForms())) {
+                        foreach ($field->getSelectedForms() as $id) {
+                            $convertkit->subscribeToFormList($id, $subscriber);
+                        }
+                    } else {
+                        $convertkit->subscribeToFormList($field->getSelectedForms(), $subscriber);
                     }
 
                     if ($field->getTagSubscribers()) {

--- a/src/FormExtension/Actions/RenderDonationFormBlock.php
+++ b/src/FormExtension/Actions/RenderDonationFormBlock.php
@@ -7,6 +7,7 @@ use Give\Framework\Blocks\BlockModel;
 use Give\Framework\FieldsAPI\Contracts\Node;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
 use GiveConvertKit\ConvertKitAPI\API;
+use GiveConvertKit\ConvertKitAPI\Subscriber;
 use GiveConvertKit\FormExtension\DonationForm\Fields\ConvertKitField;
 
 class RenderDonationFormBlock
@@ -32,25 +33,23 @@ class RenderDonationFormBlock
         return ConvertKitField::make('convertkit')
             ->label((string)$block->getAttribute('label'))
             ->checked((bool)$block->getAttribute('defaultChecked'))
-            ->selectedForms((array)$block->getAttribute('selectedForm'))
+            ->selectedForms((array)$block->getAttribute('selectedForms'))
             ->tagSubscribers((array)$block->getAttribute('tagSubscribers'))
             ->scope(function (ConvertKitField $field, $value, Donation $donation) {
                 // If the field is checked, subscribe the donor to the list.
                 if (filter_var($value, FILTER_VALIDATE_BOOLEAN)) {
                     $convertkit = give(API::class);
-                    $subscriber = \GiveConvertKit\ConvertKitAPI\Subscriber::fromDonor($donation->donor);
+                    $subscriber = Subscriber::fromDonor($donation->donor);
 
-                    if (is_array($field->getSelectedForms())) {
+                    if ($field->getSelectedForms()) {
                         foreach ($field->getSelectedForms() as $id) {
                             $convertkit->subscribeToFormList($id, $subscriber);
                         }
-                    } else {
-                        $convertkit->subscribeToFormList($field->getSelectedForms(), $subscriber);
                     }
 
                     if ($field->getTagSubscribers()) {
-                        foreach ($field->getTagSubscribers() as $tagId) {
-                            $convertkit->subscriberToTag($tagId, $subscriber);
+                        foreach ($field->getTagSubscribers() as $id) {
+                            $convertkit->subscriberToTag($id, $subscriber);
                         }
                     }
                 }

--- a/src/FormExtension/Actions/RenderDonationFormBlock.php
+++ b/src/FormExtension/Actions/RenderDonationFormBlock.php
@@ -6,6 +6,7 @@ use Give\Donations\Models\Donation;
 use Give\Framework\Blocks\BlockModel;
 use Give\Framework\FieldsAPI\Contracts\Node;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
+use Give\Log\Log;
 use GiveConvertKit\ConvertKitAPI\API;
 use GiveConvertKit\ConvertKitAPI\Subscriber;
 use GiveConvertKit\FormExtension\DonationForm\Fields\ConvertKitField;

--- a/src/FormExtension/DonationForm/Fields/ConvertKitField.php
+++ b/src/FormExtension/DonationForm/Fields/ConvertKitField.php
@@ -8,16 +8,16 @@ class ConvertKitField extends Checkbox
 {
     public const TYPE = 'convertkit';
 
-    protected $selectedForm;
+    protected $selectedForms;
 
     protected $tagSubscribers;
 
     /**
      * @unreleased
      */
-    public function selectedForms(array|string $selectedForm): ConvertKitField
+    public function selectedForms(array $selectedForms): ConvertKitField
     {
-        $this->selectedForm = $selectedForm;
+        $this->selectedForms = $selectedForms;
 
         return $this;
     }
@@ -25,9 +25,9 @@ class ConvertKitField extends Checkbox
     /**
      * @unreleased
      */
-    public function getSelectedForms(): array|string
+    public function getSelectedForms(): array
     {
-        return $this->selectedForm;
+        return $this->selectedForms;
     }
 
     /**

--- a/src/FormExtension/DonationForm/Fields/ConvertKitField.php
+++ b/src/FormExtension/DonationForm/Fields/ConvertKitField.php
@@ -3,28 +3,29 @@
 namespace GiveConvertKit\FormExtension\DonationForm\Fields;
 
 use Give\Framework\FieldsAPI\Checkbox;
-use Give\Framework\FieldsAPI\Field;
 
 class ConvertKitField extends Checkbox
 {
-    protected $selectedForm;
-    protected $tagSubscribers;
-
     public const TYPE = 'convertkit';
+
+    protected $selectedForm;
+
+    protected $tagSubscribers;
 
     /**
      * @unreleased
      */
-    public function selectedForm(string $selectedForm): ConvertKitField
+    public function selectedForms(array|string $selectedForm): ConvertKitField
     {
         $this->selectedForm = $selectedForm;
+
         return $this;
     }
 
     /**
      * @unreleased
      */
-    public function getSelectedForm(): string
+    public function getSelectedForms(): array|string
     {
         return $this->selectedForm;
     }
@@ -35,6 +36,7 @@ class ConvertKitField extends Checkbox
     public function tagSubscribers(array $tagSubscribers): ConvertKitField
     {
         $this->tagSubscribers = $tagSubscribers;
+
         return $this;
     }
 

--- a/src/FormExtension/FormBuilder/Block/BlockInspectorControls/index.tsx
+++ b/src/FormExtension/FormBuilder/Block/BlockInspectorControls/index.tsx
@@ -13,7 +13,7 @@ export default function BlockInspectorControls({ attributes, setAttributes }) {
     label,
     defaultChecked,
     tagSubscribers,
-    selectedForm = "",
+    selectedForms = [""],
   } = attributes;
 
   const tagsListOptions = tags.map(function ({ id, name }) {
@@ -65,9 +65,9 @@ export default function BlockInspectorControls({ attributes, setAttributes }) {
 
             <ListsControl
               id={"givewp-convertkit-tag-controls"}
-              onChange={(values) => setAttributes({ selectedForm: values })}
+              onChange={(values) => setAttributes({ selectedForms: values })}
               lists={forms}
-              selectedLists={selectedForm}
+              selectedLists={selectedForms}
             />
 
             <TagControls

--- a/src/FormExtension/FormBuilder/Block/BlockInspectorControls/index.tsx
+++ b/src/FormExtension/FormBuilder/Block/BlockInspectorControls/index.tsx
@@ -13,7 +13,7 @@ export default function BlockInspectorControls({ attributes, setAttributes }) {
     label,
     defaultChecked,
     tagSubscribers,
-    selectedForms = [""],
+    selectedForms,
   } = attributes;
 
   const tagsListOptions = tags.map(function ({ id, name }) {
@@ -64,7 +64,7 @@ export default function BlockInspectorControls({ attributes, setAttributes }) {
             />
 
             <ListsControl
-              id={"givewp-convertkit-tag-controls"}
+              id={"givewp-convertkit-controls-lists"}
               onChange={(values) => setAttributes({ selectedForms: values })}
               lists={forms}
               selectedLists={selectedForms}

--- a/src/FormExtension/FormBuilder/Block/metadata.ts
+++ b/src/FormExtension/FormBuilder/Block/metadata.ts
@@ -1,37 +1,38 @@
-import type {BlockConfiguration} from '@wordpress/blocks';
-import {__} from '@wordpress/i18n';
+import type { BlockConfiguration } from "@wordpress/blocks";
+import { __ } from "@wordpress/i18n";
 
 /**
  * @unreleased
  */
 const metadata: BlockConfiguration = {
-    name: 'givewp-convertkit/convertkit',
-    title: __('ConvertKit', 'give-convertkit'),
-    description: __(
-        'Easily integrate ConvertKit opt-ins within your Give donation forms.',
-        'give-convertkit'
-    ),
-    category: 'addons',
-    supports: {
-        multiple: false,
+  name: "givewp-convertkit/convertkit",
+  title: __("ConvertKit", "give-convertkit"),
+  description: __(
+    "Easily integrate ConvertKit opt-ins within your Give donation forms.",
+    "give-convertkit"
+  ),
+  category: "addons",
+  supports: {
+    multiple: false,
+  },
+  attributes: {
+    label: {
+      type: "string",
+      default: __("Subscribe to our newsletter?", "give-convertkit"),
     },
-    attributes: {
-        label: {
-            type: 'string',
-            default: __('Subscribe to newsletter?', 'give'),
-        },
-        defaultChecked: {
-            type: 'boolean',
-            default: true,
-        },
-        selectedForm: {
-            type: 'string',
-        },
-        tagSubscribers: {
-            type: 'array',
-            default: [],
-        },
+    defaultChecked: {
+      type: "boolean",
+      default: true,
     },
+    selectedForms: {
+      type: "array",
+      default: [],
+    },
+    tagSubscribers: {
+      type: "array",
+      default: [],
+    },
+  },
 };
 
 export default metadata;


### PR DESCRIPTION
## Description

The main purpose of this PR is to update the attribute selectForm to selectedForms. It's now represented as an array as opposed to a string, which enables admins to subscribe emails into multiple forms/landing pages at one time from within the VFB.

Additional changes include:
- added types in the Api class.
- improved logging within the subscribe method.
- new ID for lists control.


## Affects
VFB ConvertKit

## Visuals


https://github.com/impress-org/give-convertkit/assets/75056371/d0708140-fcaa-4f97-88ae-f893fd8ba06d




## Testing Instructions
- Create a v3 form with the Convertkit Block
- On Convertkit create multiple forms or pages 
- Verify that they are imported into the VFB correctly
- Process a donation and subscribe to the newsletter
- Check the logs, verify that the logging mechanism works as expected, you should see a log for each subscription & tag

## Pre-review Checklist
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

